### PR TITLE
Fix remove condition in debian prerm

### DIFF
--- a/package/DEBIAN/prerm
+++ b/package/DEBIAN/prerm
@@ -1,7 +1,9 @@
 #!/bin/sh
 
+set -e
+
 # Only remove if it's not an upgrade
-if [ $1 == 0 ];then
+if [ "$1" != "upgrade" ]; then
     /usr/bin/libsysinternalsEBPFinstaller -u
     ldconfig
 fi


### PR DESCRIPTION
Current version gives error during remove/purge/upgrade:
`/var/lib/dpkg/info/sysinternalsebpf.prerm: 4: [: remove: unexpected operator`
this is because of `==`, it should be `=` for `[` command, see https://tldp.org/HOWTO/Bash-Prog-Intro-HOWTO-11.html

but also `$1` should be compared with correct value, like `remove`/`upgrade`/etc, see
https://www.debian.org/doc/debian-policy/ch-maintainerscripts.html

btw, you can also check some "reference" examples in your debian-based system: `cat /var/lib/dpkg/info/*.prerm|less`, in case if you will need some more complicated logic for different package actions.